### PR TITLE
general experimentation refactoring, add data file watcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ htmlcov/
 venv/
 ENV/
 
+node_modules/
+
 .DS_Store
 
 *checkpoint*

--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ export TF_BINARY_URL=https://storage.googleapis.com/tensorflow/linux/cpu/tensorf
 sudo pip install --upgrade $TF_BINARY_URL
 ```
 
+For auto file copier, we use Gulp.
+
+```shell
+npm install --global gulp-cli
+npm install --save-dev gulp gulp-watch gulp-changed
+```
+
 ### Complete
 
 To run more than just the classic control gym env, we need to install the OpenAI gym fully. We refer to the [Install Everything](https://github.com/openai/gym#installing-everything) of the repo (which is still broken at the time of writing).
@@ -74,6 +81,8 @@ env.render()
 ```
 
 ## Usage
+
+First run `gulp` to setup watcher for automatically copying data files.
 
 The scripts are inside the `rl/` folder. Configure your `game_specs` in `rl/session.py`, and run
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,13 @@
+const gulp = require('gulp')
+const watch = require('gulp-watch')
+const changed = require('gulp-changed')
+
+const source = './data'
+const destination = '/keybase/private/kengz,lgraesser/data';
+
+gulp.task('default', function() {
+  gulp.src(source + '/*', { base: source })
+    .pipe(watch(source, { base: source }))
+    .pipe(changed(destination))
+    .pipe(gulp.dest(destination));
+});

--- a/package.json
+++ b/package.json
@@ -27,5 +27,10 @@
   "bugs": {
     "url": "https://github.com/kengz/openai_gym/issues"
   },
-  "homepage": "https://github.com/kengz/openai_gym#readme"
+  "homepage": "https://github.com/kengz/openai_gym#readme",
+  "devDependencies": {
+    "gulp": "^3.9.1",
+    "gulp-changed": "^1.3.2",
+    "gulp-watch": "^4.3.11"
+  }
 }

--- a/rl/agent/base_agent.py
+++ b/rl/agent/base_agent.py
@@ -42,5 +42,7 @@ class Agent(object):
     def train(self, sys_vars):
         raise NotImplementedError()
 
+    # TODO perhaps refactor under update()
+    # or use a smooth decay
     def recompile_model(self, params, sys_vars):
         raise NotImplementedError()

--- a/rl/experiment.py
+++ b/rl/experiment.py
@@ -299,7 +299,7 @@ class Session(object):
         sys_vars['mean_rewards_history'].append(mean_rewards)
         sys_vars['solved'] = solved
 
-        # self.grapher.plot()
+        self.grapher.plot()
         self.check_end()
         return sys_vars
 

--- a/rl/experiment.py
+++ b/rl/experiment.py
@@ -184,8 +184,7 @@ class Session(object):
         # init all things, so a session can only be ran once
         self.sys_vars = self.init_sys_vars()
         self.env = gym.make(self.sys_vars['GYM_ENV_NAME'])
-        self.env_spec = get_env_spec(self.env)
-        self.set_state_dim()
+        self.env_spec = self.set_env_spec()
         self.agent = self.Agent(self.env_spec, **self.param)
         self.memory = self.Memory(**self.param)
         self.policy = self.Policy(**self.param)
@@ -229,7 +228,27 @@ class Session(object):
         sys_keys = self.sys_vars.keys()
         assert all(k in sys_keys for k in REQUIRED_SYS_KEYS)
 
+    def set_env_spec(self):
+        '''Helper: return the env specs: dims, actions, reward range'''
+        env = self.env
+        state_dim = env.observation_space.shape[0]
+        if (len(env.observation_space.shape) > 1):
+            state_dim = env.observation_space.shape
+        self.env_spec = {
+            'state_dim': state_dim,
+            'state_bounds': np.transpose(
+                [env.observation_space.low, env.observation_space.high]),
+            'action_dim': env.action_space.n,
+            'actions': list(range(env.action_space.n)),
+            'reward_range': env.reward_range,
+            'timestep_limit': env.spec.tags.get(
+                'wrapper_config.TimeLimit.max_episode_steps')
+        }
+        self.set_state_dim()  # preprocess
+        return self.env_spec
+
     def set_state_dim(self):
+        '''helper to tweak env_spec according to preprocessor'''
         if self.PreProcessor is StackStates:
             self.env_spec['state_dim'] = self.env_spec['state_dim'] * 2
         elif self.PreProcessor is Atari:

--- a/rl/experiment.py
+++ b/rl/experiment.py
@@ -71,7 +71,7 @@ class Grapher(object):
         self.graph_filename = self.session.graph_filename
         self.subgraphs = {}
         self.figure = self.plt.figure(facecolor='white', figsize=(8, 9))
-        self.figure.suptitle(self.session.session_id)
+        self.figure.suptitle(wrap_text(self.session.session_id))
         self.init_figure()
 
     def init_figure(self):

--- a/rl/util.py
+++ b/rl/util.py
@@ -8,6 +8,7 @@ import numpy as np
 import os
 from datetime import datetime, timedelta
 from os import path, environ
+from textwrap import wrap
 
 
 # parse_args to add flag
@@ -42,21 +43,8 @@ def log_self(subject):
         to_json(subject.__dict__)))
 
 
-def get_env_spec(env):
-    '''Helper: return the env specs: dims, actions, reward range'''
-    state_dim = env.observation_space.shape[0]
-    if (len(env.observation_space.shape) > 1):
-        state_dim = env.observation_space.shape
-    return {
-        'state_dim': state_dim,
-        'state_bounds': np.transpose(
-            [env.observation_space.low, env.observation_space.high]),
-        'action_dim': env.action_space.n,
-        'actions': list(range(env.action_space.n)),
-        'reward_range': env.reward_range,
-        'timestep_limit': env.spec.tags.get(
-            'wrapper_config.TimeLimit.max_episode_steps')
-    }
+def wrap_text(text):
+    return '\n'.join(wrap(text, 60))
 
 
 def print_line(line='-'):
@@ -91,10 +79,6 @@ def timestamp_elapse_to_seconds(s1):
     a = datetime.strptime(s1, '%H:%M:%S')
     secs = timedelta(hours=a.hour, minutes=a.minute, seconds=a.second).seconds
     return secs
-
-
-def seconds_to_timestamp_elapse(secs):
-    return
 
 
 def basic_stats(array):


### PR DESCRIPTION
To make the code even cleaner before we ramp up to run an explosive amount of experiments on hyper param selection.

- [x] use textwrap to fix truncated matplotlib graph title
- [x] add gulp for auto file copier to keybase (no manual copy, `./data` is now autosynced)