### PR TITLE
Preprocessing refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,11 @@ Tl;dr:
 # run locally
 npm start
 # run from remote after logging in to ssh
+# launch screen first, then run
+screen
 npm run remote
+# use Cmd+A+D to detach from screen, then Cmd+D to disconnect ssh
+# use screen -r to resume screen next time
 ```
 
 The scripts are inside the `rl/` folder. Configure your `game_specs` in `rl/session.py`, and run

--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ env.render()
 
 First run `gulp` to setup watcher for automatically copying data files.
 
+Tl;dr:
+
+```shell
+# run locally
+npm start
+# run from remote after logging in to ssh
+npm run remote
+```
+
 The scripts are inside the `rl/` folder. Configure your `game_specs` in `rl/session.py`, and run
 
 ```shell

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,7 +6,7 @@ const source = './data'
 const destination = '/keybase/private/kengz,lgraesser/data';
 
 gulp.task('default', function() {
-  gulp.src(source + '/*', { base: source })
+  gulp.src(source + '/**/*', { base: source })
     .pipe(watch(source, { base: source }))
     .pipe(changed(destination))
     .pipe(gulp.dest(destination));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,7 +6,7 @@ const source = './data'
 const destination = '/keybase/private/kengz,lgraesser/data';
 
 gulp.task('default', function() {
-  gulp.src(source + '/**/*', { base: source })
+  gulp.src([source + '/**/*', source + '/*'], { base: source })
     .pipe(watch(source, { base: source }))
     .pipe(changed(destination))
     .pipe(gulp.dest(destination));

--- a/main.py
+++ b/main.py
@@ -1,8 +1,9 @@
 from rl.experiment import run
 
 if __name__ == '__main__':
-    run('dev_dqn', times=2, param_selection=True)
+    # run('dev_dqn', times=2, param_selection=True)
     # run('dqn', times=2, param_selection=False)
-    # run('lunar_dqn', times=1, param_selection=False)
+    run('lunar_dqn', times=3, param_selection=True)
     # run('DevCartPole-v0_DQN_HighLowMemoryWithForgetting_BoltzmannPolicy_NoPreProcessor_2017-01-21_191023_e0', plot_only=True)
     # run('lunar_dqn', times=3, param_selection=True, line_search=True)
+    # run('breakout_dqn', times=1, param_selection=True)

--- a/main.py
+++ b/main.py
@@ -1,10 +1,8 @@
 from rl.experiment import run
 
 if __name__ == '__main__':
-    # ['dummy', 'q_table', 'lunar_double_dqn',
-    #     'mountain_double_dqn', 'lunar_dqn', 'double_dqn', 'dqn']
-    # run('dev_dqn', times=1, param_selection=False)
-    run('lunar_dqn', times=1, param_selection=False)
+    run('dev_dqn', times=2, param_selection=True)
     # run('dqn', times=2, param_selection=False)
-    # run('CartPole-v0_DQN_LinearMemoryWithForgetting_BoltzmannPolicy_2017-01-14_201002_e1', plot_only=True)
+    # run('lunar_dqn', times=1, param_selection=False)
+    # run('DevCartPole-v0_DQN_HighLowMemoryWithForgetting_BoltzmannPolicy_NoPreProcessor_2017-01-21_191023_e0', plot_only=True)
     # run('lunar_dqn', times=3, param_selection=True, line_search=True)

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ from rl.experiment import run
 if __name__ == '__main__':
     # run('dev_dqn', times=2, param_selection=True)
     # run('dqn', times=2, param_selection=False)
-    run('lunar_dqn', times=3, param_selection=True)
+    run('lunar_dqn', times=5, param_selection=True)
     # run('DevCartPole-v0_DQN_HighLowMemoryWithForgetting_BoltzmannPolicy_NoPreProcessor_2017-01-21_191023_e0', plot_only=True)
     # run('lunar_dqn', times=3, param_selection=True, line_search=True)
     # run('breakout_dqn', times=1, param_selection=True)

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "start": "python3 main.py -b | tee -a ./data/terminal.log",
+    "remote": "xvfb-run -a -s \"-screen 0 1400x900x24\" -- npm start",
     "test": "python3 setup.py test",
     "posttest": "rm -rf .cache __pycache__ */__pycache__ *egg-info htmlcov",
     "clear": "rm -rf .cache __pycache__ */__pycache__ *egg-info htmlcov .coverage data/**/ data/*.log"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "python3 main.py -b | tee -a ./data/terminal.log",
     "test": "python3 setup.py test",
     "posttest": "rm -rf .cache __pycache__ */__pycache__ *egg-info htmlcov",
-    "clear": "rm -rf .cache __pycache__ */__pycache__ *egg-info htmlcov .coverage data/*.png data/*.json data/*.log data/*.csv"
+    "clear": "rm -rf .cache __pycache__ */__pycache__ *egg-info htmlcov .coverage data/**/ data/*.log"
   },
   "repository": {
     "type": "git",

--- a/rl/agent/atari_conv_dqn.py
+++ b/rl/agent/atari_conv_dqn.py
@@ -1,11 +1,8 @@
-import numpy as np
-from rl.util import logger
 from rl.agent.dqn import DQN
 from rl.util import logger
 from keras.models import Sequential
 from keras.layers.core import Dense, Flatten
 from keras.layers.convolutional import Convolution2D
-from keras.layers.pooling import MaxPooling2D
 from keras.optimizers import RMSprop
 from keras.constraints import maxnorm
 from keras import backend as K

--- a/rl/agent/atari_conv_dqn.py
+++ b/rl/agent/atari_conv_dqn.py
@@ -8,6 +8,7 @@ from keras.constraints import maxnorm
 from keras import backend as K
 K.set_image_dim_ordering('tf')
 
+
 class ConvDQN(DQN):
 
     def __init__(self, *args, **kwargs):
@@ -17,28 +18,32 @@ class ConvDQN(DQN):
         '''
         build the hidden layers into model using parameter self.hidden_layers
         '''
-        model.add(Convolution2D(self.hidden_layers[0][0],
-                                self.hidden_layers[0][1],
-                                self.hidden_layers[0][2],
-                                subsample=self.hidden_layers[0][3],
-                                input_shape=(self.env_spec['state_dim']),
-                                activation=self.hidden_layers_activation,
-                                init='lecun_uniform',
-                                W_constraint=maxnorm(3)))
+        model.add(
+            Convolution2D(
+                self.hidden_layers[0][0],
+                self.hidden_layers[0][1],
+                self.hidden_layers[0][2],
+                subsample=self.hidden_layers[0][3],
+                input_shape=(self.env_spec['state_dim']),
+                activation=self.hidden_layers_activation,
+                init='lecun_uniform',
+                W_constraint=maxnorm(3)))
 
         if (len(self.hidden_layers) > 1):
             for i in range(1, len(self.hidden_layers)):
-                model.add(Convolution2D(self.hidden_layers[i][0],
-                                self.hidden_layers[i][1],
-                                self.hidden_layers[i][2],
-                                subsample=self.hidden_layers[i][3],
-                                activation=self.hidden_layers_activation,
-                                init='lecun_uniform',
-                                W_constraint=maxnorm(3)))
+                model.add(
+                    Convolution2D(
+                        self.hidden_layers[i][0],
+                        self.hidden_layers[i][1],
+                        self.hidden_layers[i][2],
+                        subsample=self.hidden_layers[i][3],
+                        activation=self.hidden_layers_activation,
+                        init='lecun_uniform',
+                        W_constraint=maxnorm(3)))
         model.add(Flatten())
-        model.add(Dense(256, init='lecun_uniform', 
-                                                    activation=self.hidden_layers_activation,
-                                                    W_constraint=maxnorm(3)))
+        model.add(Dense(256, init='lecun_uniform',
+                        activation=self.hidden_layers_activation,
+                        W_constraint=maxnorm(3)))
         return model
 
     def build_model(self):
@@ -48,9 +53,9 @@ class ConvDQN(DQN):
 
         model = Sequential()
         self.build_hidden_layers(model)
-        model.add(Dense(self.env_spec['action_dim'], 
-                                            init='lecun_uniform',
-                                            W_constraint=maxnorm(3)))
+        model.add(Dense(self.env_spec['action_dim'],
+                        init='lecun_uniform',
+                        W_constraint=maxnorm(3)))
 
         logger.info("Model summary")
         model.summary()

--- a/rl/agent/atari_conv_dqn.py
+++ b/rl/agent/atari_conv_dqn.py
@@ -64,12 +64,17 @@ class ConvDQN(DQN):
         logger.info("Model built and compiled")
         return self.model
 
-    def recompile_model(self, new_lr):
+    def recompile_model(self, params, sys_vars):
         '''
         Option to change model optimizer settings
         Doesn't do anything at the moment
         '''
-        self.learning_rate = new_lr
-        self.optimizer = RMSprop()
-        self.model.compile(loss='mean_squared_error', optimizer=self.optimizer)
-        logger.info("Model recompiled but optimizer set to RMSProp so it didn't do anything")
+        if 'epi_change_learning_rate' in params:
+            if (sys_vars['epi'] == params['epi_change_learning_rate']):
+                self.learning_rate = self.learning_rate / 10.0
+                self.optimizer = RMSprop(lr=self.learning_rate)
+                self.model.compile(
+                    loss='mean_squared_error', optimizer=self.optimizer)
+                logger.info('Model recompiled with new settings: '
+                            'Learning rate: {}'.format(self.learning_rate))
+        return self.model

--- a/rl/agent/atari_conv_dqn.py
+++ b/rl/agent/atari_conv_dqn.py
@@ -63,18 +63,3 @@ class ConvDQN(DQN):
         self.model.compile(loss='mean_squared_error', optimizer=self.optimizer)
         logger.info("Model built and compiled")
         return self.model
-
-    def recompile_model(self, params, sys_vars):
-        '''
-        Option to change model optimizer settings
-        Doesn't do anything at the moment
-        '''
-        if 'epi_change_learning_rate' in params:
-            if (sys_vars['epi'] == params['epi_change_learning_rate']):
-                self.learning_rate = self.learning_rate / 10.0
-                self.optimizer = RMSprop(lr=self.learning_rate)
-                self.model.compile(
-                    loss='mean_squared_error', optimizer=self.optimizer)
-                logger.info('Model recompiled with new settings: '
-                            'Learning rate: {}'.format(self.learning_rate))
-        return self.model

--- a/rl/agent/base_agent.py
+++ b/rl/agent/base_agent.py
@@ -20,10 +20,11 @@ class Agent(object):
         setattr(memory, 'agent', self)
         setattr(policy, 'agent', self)
         setattr(preprocessor, 'agent', self)
-        logger.info('Compiled:\nAgent, Memory, Policy, Preprocessor:\n{}'.format(
-            ', '.join([comp.__class__.__name__ for comp in [
-                self, memory, policy, preprocessor]])
-        ))
+        logger.info(
+            'Compiled:\nAgent, Memory, Policy, Preprocessor:\n{}'.format(
+                ', '.join([comp.__class__.__name__ for comp in [
+                    self, memory, policy, preprocessor]])
+            ))
 
     def select_action(self, state):
         self.policy.select_action(state)
@@ -40,9 +41,4 @@ class Agent(object):
         raise NotImplementedError()
 
     def train(self, sys_vars):
-        raise NotImplementedError()
-
-    # TODO perhaps refactor under update()
-    # or use a smooth decay
-    def recompile_model(self, params, sys_vars):
         raise NotImplementedError()

--- a/rl/agent/base_agent.py
+++ b/rl/agent/base_agent.py
@@ -31,9 +31,7 @@ class Agent(object):
         raise NotImplementedError()
 
     def update(self, sys_vars):
-        '''
-        Agent update apart from training the Q function
-        '''
+        '''Agent update apart from training the Q function'''
         self.policy.update(sys_vars)
         raise NotImplementedError()
 

--- a/rl/agent/double_dqn.py
+++ b/rl/agent/double_dqn.py
@@ -43,7 +43,7 @@ class DoubleDQN(DQN):
         '''
 
         loss_total = 0
-        for epoch in range(self.n_epoch):
+        for _epoch in range(self.n_epoch):
             minibatch = self.memory.rand_minibatch(self.batch_size)
             # note the computed values below are batched in array
             Q_states = self.model.predict(minibatch['states'])

--- a/rl/agent/dqn.py
+++ b/rl/agent/dqn.py
@@ -19,6 +19,7 @@ class DQN(Agent):
     def __init__(self, env_spec,
                  train_per_n_new_exp=1,
                  gamma=0.95, learning_rate=0.1,
+                 epi_change_learning_rate=None,
                  batch_size=16, n_epoch=5, hidden_layers_shape=[4],
                  hidden_layers_activation='sigmoid',
                  output_layer_activation='linear',
@@ -28,6 +29,7 @@ class DQN(Agent):
         self.train_per_n_new_exp = train_per_n_new_exp
         self.gamma = gamma
         self.learning_rate = learning_rate
+        self.epi_change_learning_rate = epi_change_learning_rate
         self.batch_size = batch_size
         self.n_epoch = 1
         self.final_n_epoch = n_epoch
@@ -73,16 +75,17 @@ class DQN(Agent):
         logger.info("Model built and compiled")
         return self.model
 
-    def recompile_model(self, params, sys_vars):
+    def recompile_model(self, sys_vars):
         '''
         Option to change model optimizer settings
         Currently only used for changing the learning rate
         Compiling does not affect the model weights
         '''
-        if 'epi_change_learning_rate' in params:
-            if (sys_vars['epi'] == params['epi_change_learning_rate']):
+        if self.epi_change_learning_rate is not None:
+            if (sys_vars['epi'] == self.epi_change_learning_rate and
+                    sys_vars['t'] == 0):
                 self.learning_rate = self.learning_rate / 10.0
-                self.optimizer = SGD(lr=self.learning_rate)
+                self.optimizer = type(self.optimizer)(lr=self.learning_rate)
                 self.model.compile(
                     loss='mean_squared_error', optimizer=self.optimizer)
                 logger.info('Model recompiled with new settings: '
@@ -112,6 +115,7 @@ class DQN(Agent):
         '''
         self.policy.update(sys_vars)
         self.update_n_epoch(sys_vars)
+        self.recompile_model(sys_vars)
 
     def to_train(self, sys_vars):
         '''

--- a/rl/agent/dqn.py
+++ b/rl/agent/dqn.py
@@ -137,7 +137,7 @@ class DQN(Agent):
         step 1,2,3,4 of algo.
         '''
         loss_total = 0
-        for epoch in range(self.n_epoch):
+        for _epoch in range(self.n_epoch):
             minibatch = self.memory.rand_minibatch(self.batch_size)
             # note the computed values below are batched in array
             Q_states = self.model.predict(minibatch['states'])

--- a/rl/agent/dqn.py
+++ b/rl/agent/dqn.py
@@ -123,9 +123,9 @@ class DQN(Agent):
         get n NEW experiences before training model
         '''
         t = sys_vars['t']
+        done = sys_vars['done']
         timestep_limit = self.env_spec['timestep_limit']
-        done = self.memory.pop()['terminals'][0]
-        return bool(
+        return (t > 0) and bool(
             t % self.train_per_n_new_exp == 0 or
             t == (timestep_limit-1) or
             done)

--- a/rl/agent/dummy.py
+++ b/rl/agent/dummy.py
@@ -21,6 +21,3 @@ class Dummy(Agent):
 
     def train(self, sys_vars):
         return
-
-    def recompile_model(self, params, sys_vars):
-        return

--- a/rl/agent/q_table.py
+++ b/rl/agent/q_table.py
@@ -100,7 +100,3 @@ class QTable(Agent):
         self.qtable[flat_state, action] = Q_state_action + \
             self.learning_rate * loss
         return self.qtable
-
-    def recompile_model(self, params, sys_vars):
-        ''' Function not needed for non neural network based agents'''
-        return

--- a/rl/asset/problems.json
+++ b/rl/asset/problems.json
@@ -3,7 +3,7 @@
     "RENDER": true,
     "GYM_ENV_NAME": "CartPole-v0",
     "SOLVED_MEAN_REWARD": 195.0,
-    "MAX_EPISODES": 26,
+    "MAX_EPISODES": 10,
     "REWARD_MEAN_LEN": 100
   },
   "CartPole-v0": {

--- a/rl/asset/sess_specs.json
+++ b/rl/asset/sess_specs.json
@@ -204,15 +204,16 @@
                 [32, 4, 4, [2, 2]]
             ],
             "hidden_layers_activation": "relu",
-            "exploration_anneal_episodes": 1000000,
-            "epi_change_learning_rate": 1000000
+            "exploration_anneal_episodes": 5000,
+            "epi_change_learning_rate": 5000
         },
         "param_range": {
             "learning_rate": [0.001, 0.01],
             "hidden_layers_shape": [
-                [200, 100],
-                [300, 200],
-                [200, 100, 50]
+                [
+                    [16, 8, 8, [4, 4]],
+                    [32, 4, 4, [2, 2]]
+                ]
             ]
         }
     }

--- a/rl/experiment.py
+++ b/rl/experiment.py
@@ -8,6 +8,7 @@ import warnings
 import numpy as np
 import platform
 import pandas as pd
+import traceback
 from keras import backend as K
 from os import environ
 from rl.util import *
@@ -353,9 +354,9 @@ class Session(object):
             sys_vars['epi'] = epi  # update sys_vars epi
             try:
                 self.run_episode()
-            except Exception as e:
-                logger.error(str(e))
+            except Exception:
                 logger.error('Error in experiment, terminating')
+                traceback.print_exc(file=sys.stdout)
                 break
             if sys_vars['solved']:
                 break

--- a/rl/experiment.py
+++ b/rl/experiment.py
@@ -604,7 +604,7 @@ def analyze_param_space(experiment_data_array_or_prefix_id):
 
 
 def run(sess_name_id_spec, times=1,
-        param_selection=False, line_search=True,
+        param_selection=False, line_search=False,
         plot_only=False):
     '''
     primary method:

--- a/rl/experiment.py
+++ b/rl/experiment.py
@@ -10,7 +10,7 @@ import platform
 import pandas as pd
 import traceback
 from keras import backend as K
-from os import environ
+from os import path, environ
 from rl.util import *
 from rl.agent import *
 from rl.memory import *

--- a/rl/experiment.py
+++ b/rl/experiment.py
@@ -25,6 +25,7 @@ if environ.get('CI') or platform.system() == 'Darwin':
 else:
     matplotlib.rcParams['backend'] = 'TkAgg'
 
+np.seterr(all='warn')
 warnings.filterwarnings("ignore", module="matplotlib")
 
 GREF = globals()

--- a/rl/experiment.py
+++ b/rl/experiment.py
@@ -353,7 +353,8 @@ class Session(object):
             sys_vars['epi'] = epi  # update sys_vars epi
             try:
                 self.run_episode()
-            except:
+            except Exception as e:
+                logger.error(str(e))
                 logger.error('Error in experiment, terminating')
                 break
             if sys_vars['solved']:

--- a/rl/experiment.py
+++ b/rl/experiment.py
@@ -25,7 +25,7 @@ if environ.get('CI') or platform.system() == 'Darwin':
 else:
     matplotlib.rcParams['backend'] = 'TkAgg'
 
-np.seterr(all='warn')
+np.seterr(all='raise')
 warnings.filterwarnings("ignore", module="matplotlib")
 
 GREF = globals()
@@ -351,7 +351,11 @@ class Session(object):
         sys_vars['time_start'] = timestamp()
         for epi in range(sys_vars['MAX_EPISODES']):
             sys_vars['epi'] = epi  # update sys_vars epi
-            self.run_episode()
+            try:
+                self.run_episode()
+            except:
+                logger.error('Error in experiment, terminating')
+                break
             if sys_vars['solved']:
                 break
 

--- a/rl/experiment.py
+++ b/rl/experiment.py
@@ -192,7 +192,8 @@ class Session(object):
         self.agent.compile(self.memory, self.policy, self.preprocessor)
 
         # data file and graph
-        self.base_filename = './data/{}'.format(self.session_id)
+        self.base_filename = './data/{}/{}'.format(
+            self.experiment.prefix_id, self.session_id)
         self.graph_filename = self.base_filename + '.png'
 
         # for plotting
@@ -416,7 +417,10 @@ class Experiment(object):
             self.run_timestamp
         )
         self.experiment_id = self.prefix_id + '_e' + str(self.experiment_num)
-        self.base_filename = './data/{}'.format(self.experiment_id)
+        self.base_dir = './data/{}'.format(self.prefix_id)
+        os.makedirs(self.base_dir, exist_ok=True)
+        self.base_filename = './data/{}/{}'.format(
+            self.prefix_id, self.experiment_id)
         self.data_filename = self.base_filename + '.json'
         log_delimiter('Init Experiment:\n{}'.format(self.experiment_id), '=')
 
@@ -582,7 +586,7 @@ def analyze_param_space(experiment_data_array_or_prefix_id):
     experiment_id = experiment_data_array[0]['experiment_id']
     prefix_id = prefix_id_from_experiment_id(experiment_id)
     metrics_df.to_csv(
-        './data/param_space_data_{}.csv'.format(prefix_id),
+        './data/{0}/param_space_data_{0}.csv'.format(prefix_id),
         index=False)
     return metrics_df
 

--- a/rl/experiment.py
+++ b/rl/experiment.py
@@ -477,7 +477,7 @@ class Experiment(object):
     def to_stop(self):
         '''check of experiment should be continued'''
         metrics = self.data['summary']['metrics']
-        failed = metrics['solved_num_of_sessions'] == 0
+        failed = metrics['solved_ratio_of_sessions'] < 1.
         if failed:
             logger.info(
                 'Failed experiment, terminating sessions for {}'.format(

--- a/rl/experiment.py
+++ b/rl/experiment.py
@@ -326,7 +326,7 @@ class Session(object):
 
             processed_state = agent.preprocessor.preprocess_state()
             action = agent.select_action(processed_state)
-            next_state, reward, done, info = env.step(action)
+            next_state, reward, done, _info = env.step(action)
             processed_exp = agent.preprocessor.preprocess_memory(
                 action, reward, next_state, done)
             if processed_exp is not None:

--- a/rl/experiment.py
+++ b/rl/experiment.py
@@ -355,7 +355,8 @@ class Session(object):
             try:
                 self.run_episode()
             except Exception:
-                logger.error('Error in experiment, terminating')
+                logger.error('Error in experiment, terminating '
+                             'further session from {}'.format(self.session_id))
                 traceback.print_exc(file=sys.stdout)
                 break
             if sys_vars['solved']:

--- a/rl/experiment.py
+++ b/rl/experiment.py
@@ -174,7 +174,8 @@ class Session(object):
         self.num_of_sessions = num_of_sessions
         self.session_id = self.experiment.experiment_id + \
             '_s' + str(self.session_num)
-        log_delimiter('Init Session:\n{}'.format(self.session_id))
+        log_delimiter('Init Session #{} of {}:\n{}'.format(
+            self.session_num, self.num_of_sessions, self.session_id))
 
         self.sess_spec = experiment.sess_spec
         self.problem = self.sess_spec['problem']
@@ -347,7 +348,8 @@ class Session(object):
 
     def run(self):
         '''run a session of agent'''
-        log_delimiter('Run Session:\n{}'.format(self.session_id))
+        log_delimiter('Run Session #{} of {}\n{}'.format(
+            self.session_num, self.num_of_sessions, self.session_id))
         sys_vars = self.sys_vars
         sys_vars['time_start'] = timestamp()
         for epi in range(sys_vars['MAX_EPISODES']):
@@ -426,7 +428,9 @@ class Experiment(object):
         self.base_filename = './data/{}/{}'.format(
             self.prefix_id, self.experiment_id)
         self.data_filename = self.base_filename + '.json'
-        log_delimiter('Init Experiment:\n{}'.format(self.experiment_id), '=')
+        log_delimiter('Init Experiment #{} of {}:\n{}'.format(
+            self.experiment_num, self.num_of_experiments,
+            self.experiment_id), '=')
 
     def analyze(self):
         '''mean_rewards_per_epi

--- a/rl/experiment.py
+++ b/rl/experiment.py
@@ -354,7 +354,6 @@ class Session(object):
         for epi in range(sys_vars['MAX_EPISODES']):
             sys_vars['epi'] = epi  # update sys_vars epi
             self.run_episode()
-            self.agent.recompile_model(self.param, self.sys_vars)
             if sys_vars['solved']:
                 break
 
@@ -592,7 +591,8 @@ def analyze_param_space(experiment_data_array_or_prefix_id):
     param_space_data_filename = './data/{0}/param_space_data_{0}.csv'.format(
         prefix_id)
     metrics_df.to_csv(param_space_data_filename, index=False)
-    logger.info('Param space data saved to {}'.format(param_space_data_filename))
+    logger.info(
+        'Param space data saved to {}'.format(param_space_data_filename))
     return metrics_df
 
 

--- a/rl/memory.py
+++ b/rl/memory.py
@@ -419,7 +419,7 @@ class HighLowMemory(LinearMemory):
         buffer_exp = self.exp
         minibatch_as_list = []
         if high_samples > 0:
-            for i in range(4):
+            for _i in range(4):
                 idx = np.random.randint(0, len(self.epi_memory_high))
                 epi_exp = self.epi_memory_high[idx]['exp']
                 self.exp = epi_exp
@@ -428,7 +428,7 @@ class HighLowMemory(LinearMemory):
                 minibatch_as_list.append(epi_minibatch)
 
         if low_samples > 0:
-            for i in range(4):
+            for _i in range(4):
                 idx = np.random.randint(0, len(self.epi_memory_low))
                 epi_exp = self.epi_memory_low[idx]['exp']
                 self.exp = epi_exp

--- a/rl/memory.py
+++ b/rl/memory.py
@@ -12,16 +12,12 @@ class Memory(object):
 
     def __init__(self,
                  **kwargs):  # absorb generic param without breaking
-        '''
-        Construct externally, and set at Agent.compile()
-        '''
+        '''Construct externally, and set at Agent.compile()'''
         self.agent = None
         self.state = None
 
     def reset_state(self, init_state):
-        '''
-        reset the state of LinearMemory per episode env.reset()
-        '''
+        '''reset the state of LinearMemory per episode env.reset()'''
         self.state = init_state
 
     def add_exp(self, action, reward, next_state, terminal):

--- a/rl/memory.py
+++ b/rl/memory.py
@@ -294,7 +294,7 @@ class HighLowMemory(LinearMemory):
     Memory divided into two: good and bad experiences
     As with RankedMemory experiences are grouped episodically
     Episodes with a total reward > threshold are assigned to good memory
-    The threshold is recomputed every n episodes and 
+    The threshold is recomputed every n episodes and
     episodes are reassigned accordingly.
     Memories are sampled from good experiences with a self.prob_high
     Memories are sampled from bad experiences with a 1 - self.prob_high

--- a/rl/policy.py
+++ b/rl/policy.py
@@ -10,9 +10,7 @@ class Policy(object):
 
     def __init__(self,
                  **kwargs):  # absorb generic param without breaking
-        '''
-        Construct externally, and set at Agent.compile()
-        '''
+        '''Construct externally, and set at Agent.compile()'''
         self.agent = None
 
     def select_action(self, state):

--- a/rl/preprocessor.py
+++ b/rl/preprocessor.py
@@ -83,7 +83,7 @@ class PreProcessor(object):
         self.exp_queue.append([self.state, action, reward, next_state, done])
         # TODO parametrize max length to top
         if (self.exp_queue_size() > self.MAX_QUEUE_SIZE):
-            del exp_queue[0]
+            del self.exp_queue[0]
         self.advance_state(next_state)
 
     def preprocess_memory(self, action, reward, next_state, done):
@@ -167,7 +167,7 @@ class DiffStates(PreProcessor):
         if (self.exp_queue_size() < 1):  # insufficient queue
             return
         (state, action, reward, next_state, done) = self.exp_queue[-1]
-        processed_state = state - exp_queue[-2][0]
+        processed_state = state - self.exp_queue[-2][0]
         processed_next_state = next_state - state
         if (self.exp_queue_size() == 1):
             logger.debug("State shape: {}".format(processed_state.shape))
@@ -207,10 +207,10 @@ class Atari(PreProcessor):
             return
         (state, action, reward, next_state, done) = self.exp_queue[-1]
         processed_next_state_queue = (
-            process_image_atari(exp_queue[-1][3]),
-            process_image_atari(exp_queue[-2][3]),
-            process_image_atari(exp_queue[-3][3]),
-            process_image_atari(exp_queue[-4][3]))
+            process_image_atari(self.exp_queue[-1][3]),
+            process_image_atari(self.exp_queue[-2][3]),
+            process_image_atari(self.exp_queue[-3][3]),
+            process_image_atari(self.exp_queue[-4][3]))
         processed_state = self.preprocess_state()
         processed_next_state = np.stack(processed_next_state_queue, axis=-1)
         if (self.exp_queue_size() == 3):

--- a/rl/preprocessor.py
+++ b/rl/preprocessor.py
@@ -51,7 +51,7 @@ class PreProcessor(object):
         self.agent = None
         self.state = None
         self.exp_queue = []
-        self.state_buffer = ()
+        self.MAX_QUEUE_SIZE = 4
 
     def exp_queue_size(self):
         return len(self.exp_queue)
@@ -81,7 +81,8 @@ class PreProcessor(object):
         # Buffer currently set to hold only last 4 experiences
         # Amount needed for Atari games preprocessing
         self.exp_queue.append([self.state, action, reward, next_state, done])
-        if (len(exp_queue) > 4):
+        # TODO parametrize max length to top
+        if (self.exp_queue_size() > self.MAX_QUEUE_SIZE):
             del exp_queue[0]
         self.advance_state(next_state)
 

--- a/rl/preprocessor.py
+++ b/rl/preprocessor.py
@@ -55,9 +55,6 @@ class PreProcessor(object):
         self.exp_queue = []
         self.MAX_QUEUE_SIZE = 4
 
-    def exp_queue_size(self):
-        return len(self.exp_queue)
-
     def reset_state(self, init_state):
         '''
         reset the state of LinearMemory per episode env.reset()
@@ -69,6 +66,18 @@ class PreProcessor(object):
         self.pre_previous_state = pre_previous_state
         self.pre_pre_previous_state = pre_pre_previous_state
         return self.preprocess_state()
+
+    def exp_queue_size(self):
+        return len(self.exp_queue)
+
+    def preprocess_env_spec(self, env_spec):
+        '''helper to tweak env_spec according to preprocessor'''
+        class_name = self.__class__.__name__
+        if class_name is 'StackStates':
+            env_spec['state_dim'] = env_spec['state_dim'] * 2
+        elif class_name is 'Atari':
+            env_spec['state_dim'] = (84, 84, 4)
+        return env_spec
 
     def preprocess_state(self):
         raise NotImplementedError()

--- a/rl/preprocessor.py
+++ b/rl/preprocessor.py
@@ -60,7 +60,7 @@ class PreProcessor(object):
         '''
         reset the state of LinearMemory per episode env.reset()
         '''
-        self.state = init_state
+        self.state = np.array(init_state)  # cast into np for safety
         (previous_state, pre_previous_state,
             pre_pre_previous_state) = create_dummy_states(self.state)
         self.previous_state = previous_state

--- a/rl/preprocessor.py
+++ b/rl/preprocessor.py
@@ -193,28 +193,26 @@ class Atari(PreProcessor):
         log_self(self)
 
     def preprocess_state(self):
-        state_arrays = (process_image_atari(self.state),
-                        process_image_atari(self.previous_state),
-                        process_image_atari(self.pre_previous_state),
-                        process_image_atari(self.pre_pre_previous_state))
-        return np.stack(state_arrays, axis=-1)
+        processed_state_queue = (
+            process_image_atari(self.state),
+            process_image_atari(self.previous_state),
+            process_image_atari(self.pre_previous_state),
+            process_image_atari(self.pre_pre_previous_state))
+        processed_state = np.stack(processed_state_queue, axis=-1)
+        return processed_state
 
     def preprocess_memory(self, action, reward, next_state, done):
         self.add_exp(action, reward, next_state, done)
         if (self.exp_queue_size() < 3):  # insufficient queue
             return
         (state, action, reward, next_state, done) = self.exp_queue[-1]
-        state_arrays = (process_image_atari(exp_queue[-1][0]),
-                        process_image_atari(exp_queue[-2][0]),
-                        process_image_atari(exp_queue[-3][0]),
-                        process_image_atari(exp_queue[-4][0]))
-        next_state_arrays = (process_image_atari(exp_queue[-1][3]),
-                             process_image_atari(exp_queue[-2][3]),
-                             process_image_atari(exp_queue[-3][3]),
-                             process_image_atari(exp_queue[-4][3]))
-        processed_state = np.stack(state_arrays, axis=-1)
-        processed_next_state = np.stack(next_state_arrays, axis=-1)
-        done = exp_queue[-1][4]
+        processed_next_state_queue = (
+            process_image_atari(exp_queue[-1][3]),
+            process_image_atari(exp_queue[-2][3]),
+            process_image_atari(exp_queue[-3][3]),
+            process_image_atari(exp_queue[-4][3]))
+        processed_state = self.preprocess_state()
+        processed_next_state = np.stack(processed_next_state_queue, axis=-1)
         if (self.exp_queue_size() == 3):
             logger.debug("State shape: {}".format(processed_state.shape))
             logger.debug(

--- a/rl/preprocessor.py
+++ b/rl/preprocessor.py
@@ -119,7 +119,7 @@ class NoPreProcessor(PreProcessor):
     def preprocess_memory(self, action, reward, next_state, done):
         '''No state processing'''
         self.add_raw_exp(action, reward, next_state, done)
-        (state, action, reward, next_state, done) = self.exp_queue[-1]
+        (_state, action, reward, next_state, done) = self.exp_queue[-1]
         processed_exp = (action, reward, next_state, done)
         return processed_exp
 

--- a/rl/preprocessor.py
+++ b/rl/preprocessor.py
@@ -212,7 +212,7 @@ class Atari(PreProcessor):
         self.add_raw_exp(action, reward, next_state, done)
         if (self.exp_queue_size() < 4):  # insufficient queue
             return
-        (state, action, reward, next_state, done) = self.exp_queue[-1]
+        (_state, action, reward, next_state, done) = self.exp_queue[-1]
         processed_next_state_queue = (
             process_image_atari(self.exp_queue[-1][3]),
             process_image_atari(self.exp_queue[-2][3]),

--- a/rl/preprocessor.py
+++ b/rl/preprocessor.py
@@ -26,7 +26,7 @@ def process_image_atari(im):
 
 
 def create_dummy_states(state):
-    state_shape = state.state_shape
+    state_shape = state.shape
     previous_state = np.zeros(state_shape)
     pre_previous_state = np.zeros(state_shape)
     pre_pre_previous_state = np.zeros(state_shape)

--- a/rl/preprocessor.py
+++ b/rl/preprocessor.py
@@ -83,7 +83,6 @@ class PreProcessor(object):
         raise NotImplementedError()
 
     def advance_state(self, next_state):
-        # TODO can be generalized into a memory queue
         self.pre_pre_previous_state = self.pre_previous_state
         self.pre_previous_state = self.previous_state
         self.previous_state = self.state
@@ -95,7 +94,6 @@ class PreProcessor(object):
         Amount needed for Atari games preprocessing
         '''
         self.exp_queue.append([self.state, action, reward, next_state, done])
-        # TODO parametrize max length to top
         if (self.exp_queue_size() > self.MAX_QUEUE_SIZE):
             del self.exp_queue[0]
         self.advance_state(next_state)

--- a/rl/preprocessor.py
+++ b/rl/preprocessor.py
@@ -25,6 +25,18 @@ def process_image_atari(im):
     return im_cropped
 
 
+def create_dummy_states(state):
+    state_shape = state.state_shape
+    previous_state = np.zeros(state_shape)
+    pre_previous_state = np.zeros(state_shape)
+    pre_pre_previous_state = np.zeros(state_shape)
+    if (previous_state.ndim == 1):
+        previous_state = np.zeros([state_shape[0]])
+        pre_previous_state = np.zeros([state_shape[0]])
+        pre_pre_previous_state = np.zeros([state_shape[0]])
+    return (previous_state, pre_previous_state, pre_pre_previous_state)
+
+
 class PreProcessor(object):
 
     '''
@@ -37,14 +49,43 @@ class PreProcessor(object):
         Construct externally, and set at Agent.compile()
         '''
         self.agent = None
+        self.state = None
+        self.exp_queue = []
+        self.state_buffer = ()
 
-    def preprocess_action_sel(self, state,
-                              previous_state,
-                              pre_previous_state,
-                              pre_pre_previous_state):
+    def exp_queue_size(self):
+        return len(self.exp_queue)
+
+    def reset_state(self, init_state):
+        '''
+        reset the state of LinearMemory per episode env.reset()
+        '''
+        self.state = init_state
+        (previous_state, pre_previous_state,
+            pre_pre_previous_state) = create_dummy_states(self.state)
+        self.previous_state = previous_state
+        self.pre_previous_state = pre_previous_state
+        self.pre_pre_previous_state = pre_pre_previous_state
+
+    def preprocess_state(self):
         raise NotImplementedError()
 
-    def preprocess_memory(self, temp_exp_mem, t):
+    def advance_state(self, next_state):
+        # TODO can be generalized into a memory queue
+        self.pre_pre_previous_state = self.pre_previous_state
+        self.pre_previous_state = self.previous_state
+        self.previous_state = self.state
+        self.state = next_state
+
+    def add_exp(self, action, reward, next_state, done):
+        # Buffer currently set to hold only last 4 experiences
+        # Amount needed for Atari games preprocessing
+        self.exp_queue.append([self.state, action, reward, next_state, done])
+        if (len(exp_queue) > 4):
+            del exp_queue[0]
+        self.advance_state(next_state)
+
+    def preprocess_memory(self, action, reward, next_state, done):
         raise NotImplementedError()
 
 
@@ -59,19 +100,15 @@ class NoPreProcessor(PreProcessor):
         super(NoPreProcessor, self).__init__()
         log_self(self)
 
-    def preprocess_action_sel(self, state,
-                              previous_state,
-                              pre_previous_state,
-                              pre_pre_previous_state):
-        return state
+    def preprocess_state(self):
+        return self.state
 
-    def preprocess_memory(self, temp_exp_mem, t):
+    def preprocess_memory(self, action, reward, next_state, done):
         # No state processing
-        state = temp_exp_mem[-1][0]
-        action = temp_exp_mem[-1][1]
-        reward = temp_exp_mem[-1][2]
-        next_state = temp_exp_mem[-1][3]
-        done = temp_exp_mem[-1][4]
+        self.add_exp(action, reward, next_state, done)
+        (state, action, reward, next_state, done) = self.exp_queue[-1]
+        # TODO this is a bit odd, since now we have add_exp_processed and
+        # add_exp for memory
         self.agent.memory.add_exp_processed(
             state, action, reward,
             next_state, next_state, done)
@@ -88,30 +125,25 @@ class StackStates(PreProcessor):
         super(StackStates, self).__init__()
         log_self(self)
 
-    def preprocess_action_sel(self, state,
-                              previous_state,
-                              pre_previous_state,
-                              pre_pre_previous_state):
-        return np.concatenate([previous_state, state])
+    def preprocess_state(self):
+        return np.concatenate([self.previous_state, self.state])
 
-    def preprocess_memory(self, temp_exp_mem, t):
+    def preprocess_memory(self, action, reward, next_state, done):
         # Concatenates previous + current states
-        if (t >= 1):
-            processed_state = np.concatenate(
-                [temp_exp_mem[-2][0], temp_exp_mem[-1][0]])
-            action = temp_exp_mem[-1][1]
-            reward = temp_exp_mem[-1][2]
-            processed_next_state = np.concatenate(
-                [temp_exp_mem[-1][0], temp_exp_mem[-1][3]])
-            next_state = processed_next_state
-            done = temp_exp_mem[-1][4]
-            if (t == 1):
-                logger.debug("State shape: {}".format(processed_state.shape))
-                logger.debug(
-                    "Next state shape: {}".format(processed_next_state.shape))
-            self.agent.memory.add_exp_processed(
-                processed_state, action, reward,
-                processed_next_state, next_state, done)
+        self.add_exp(action, reward, next_state, done)
+        if (self.exp_queue_size() < 1):  # insufficient queue
+            return
+        (state, action, reward, next_state, done) = self.exp_queue[-1]
+        processed_state = np.concatenate([self.exp_queue[-2][0], state])
+        processed_next_state = np.concatenate([state, next_state])
+        if (self.exp_queue_size() == 1):
+            logger.debug("State shape: {}".format(processed_state.shape))
+            logger.debug(
+                "Next state shape: {}".format(processed_next_state.shape))
+        self.agent.memory.add_exp_processed(
+            processed_state, action, reward,
+            # TODO ensure we want to add processed_next_state as state
+            processed_next_state, processed_next_state, done)
 
 
 class DiffStates(PreProcessor):
@@ -125,28 +157,25 @@ class DiffStates(PreProcessor):
         super(DiffStates, self).__init__()
         log_self(self)
 
-    def preprocess_action_sel(self, state,
-                              previous_state,
-                              pre_previous_state,
-                              pre_pre_previous_state):
-        return state - previous_state
+    def preprocess_state(self):
+        return self.state - self.previous_state
 
-    def preprocess_memory(self, temp_exp_mem, t):
+    def preprocess_memory(self, action, reward, next_state, done):
         # Change in state params, curr_state - last_state
-        if (t >= 1):
-            processed_state = temp_exp_mem[-1][0] - temp_exp_mem[-2][0]
-            action = temp_exp_mem[-1][1]
-            reward = temp_exp_mem[-1][2]
-            processed_next_state = temp_exp_mem[-1][3] - temp_exp_mem[-1][0]
-            next_state = processed_next_state
-            done = temp_exp_mem[-1][4]
-            if (t == 1):
-                logger.debug("State shape: {}".format(processed_state.shape))
-                logger.debug(
-                    "Next state shape: {}".format(processed_next_state.shape))
-            self.agent.memory.add_exp_processed(
-                processed_state, action, reward,
-                processed_next_state, next_state, done)
+        self.add_exp(action, reward, next_state, done)
+        if (self.exp_queue_size() < 1):  # insufficient queue
+            return
+        (state, action, reward, next_state, done) = self.exp_queue[-1]
+        processed_state = state - exp_queue[-2][0]
+        processed_next_state = next_state - state
+        if (self.exp_queue_size() == 1):
+            logger.debug("State shape: {}".format(processed_state.shape))
+            logger.debug(
+                "Next state shape: {}".format(processed_next_state.shape))
+        self.agent.memory.add_exp_processed(
+            processed_state, action, reward,
+            # TODO ensure we want to add processed_next_state as state
+            processed_next_state, processed_next_state, done)
 
 
 class Atari(PreProcessor):
@@ -162,36 +191,34 @@ class Atari(PreProcessor):
         super(Atari, self).__init__()
         log_self(self)
 
-    def preprocess_action_sel(self, state,
-                              previous_state,
-                              pre_previous_state,
-                              pre_pre_previous_state):
-        arrays = (process_image_atari(state),
-                  process_image_atari(previous_state),
-                  process_image_atari(pre_previous_state),
-                  process_image_atari(pre_pre_previous_state))
-        return np.stack(arrays, axis=-1)
+    def preprocess_state(self):
+        state_arrays = (process_image_atari(self.state),
+                        process_image_atari(self.previous_state),
+                        process_image_atari(self.pre_previous_state),
+                        process_image_atari(self.pre_pre_previous_state))
+        return np.stack(state_arrays, axis=-1)
 
-    def preprocess_memory(self, temp_exp_mem, t):
-        if (t >= 3):
-            arrays = (process_image_atari(temp_exp_mem[-1][0]),
-                      process_image_atari(temp_exp_mem[-2][0]),
-                      process_image_atari(temp_exp_mem[-3][0]),
-                      process_image_atari(temp_exp_mem[-4][0]))
-            next_arrays = (process_image_atari(temp_exp_mem[-1][3]),
-                           process_image_atari(temp_exp_mem[-2][3]),
-                           process_image_atari(temp_exp_mem[-3][3]),
-                           process_image_atari(temp_exp_mem[-4][3]))
-            processed_state = np.stack(arrays, axis=-1)
-            action = temp_exp_mem[-1][1]
-            reward = temp_exp_mem[-1][2]
-            processed_next_state = np.stack(next_arrays, axis=-1)
-            next_state = processed_next_state
-            done = temp_exp_mem[-1][4]
-            if (t == 3):
-                logger.debug("State shape: {}".format(processed_state.shape))
-                logger.debug(
-                    "Next state shape: {}".format(processed_next_state.shape))
-            self.agent.memory.add_exp_processed(
-                processed_state, action, reward,
-                processed_next_state, next_state, done)
+    def preprocess_memory(self, action, reward, next_state, done):
+        self.add_exp(action, reward, next_state, done)
+        if (self.exp_queue_size() < 3):  # insufficient queue
+            return
+        (state, action, reward, next_state, done) = self.exp_queue[-1]
+        state_arrays = (process_image_atari(exp_queue[-1][0]),
+                        process_image_atari(exp_queue[-2][0]),
+                        process_image_atari(exp_queue[-3][0]),
+                        process_image_atari(exp_queue[-4][0]))
+        next_state_arrays = (process_image_atari(exp_queue[-1][3]),
+                             process_image_atari(exp_queue[-2][3]),
+                             process_image_atari(exp_queue[-3][3]),
+                             process_image_atari(exp_queue[-4][3]))
+        processed_state = np.stack(state_arrays, axis=-1)
+        processed_next_state = np.stack(next_state_arrays, axis=-1)
+        done = exp_queue[-1][4]
+        if (self.exp_queue_size() == 3):
+            logger.debug("State shape: {}".format(processed_state.shape))
+            logger.debug(
+                "Next state shape: {}".format(processed_next_state.shape))
+        self.agent.memory.add_exp_processed(
+            processed_state, action, reward,
+            # TODO ensure we want to add processed_next_state as state
+            processed_next_state, processed_next_state, done)

--- a/rl/preprocessor.py
+++ b/rl/preprocessor.py
@@ -47,18 +47,14 @@ class PreProcessor(object):
 
     def __init__(self,
                  **kwargs):  # absorb generic param without breaking
-        '''
-        Construct externally, and set at Agent.compile()
-        '''
+        '''Construct externally, and set at Agent.compile()'''
         self.agent = None
         self.state = None
         self.exp_queue = []
         self.MAX_QUEUE_SIZE = 4
 
     def reset_state(self, init_state):
-        '''
-        reset the state of LinearMemory per episode env.reset()
-        '''
+        '''reset the state of LinearMemory per episode env.reset()'''
         self.state = np.array(init_state)  # cast into np for safety
         (previous_state, pre_previous_state,
             pre_pre_previous_state) = create_dummy_states(self.state)

--- a/rl/preprocessor.py
+++ b/rl/preprocessor.py
@@ -14,11 +14,13 @@ def crop_image(im):
 
 
 def process_image_atari(im):
-    # Image preprocessing from the paper
-    # Playing Atari with Deep Reinforcement Learning, 2013
-    # Takes an RGB image and converts it to grayscale,
-    # downsizes to 110 x 84
-    # and crops to square 84 x 84, taking bottomost rows of image
+    '''
+    Image preprocessing from the paper
+    Playing Atari with Deep Reinforcement Learning, 2013
+    Takes an RGB image and converts it to grayscale,
+    downsizes to 110 x 84
+    and crops to square 84 x 84, taking bottomost rows of image
+    '''
     im_gray = np.dot(im[..., :3], [0.299, 0.587, 0.114])
     im_resized = resize_image(im_gray)
     im_cropped = crop_image(im_resized)
@@ -78,8 +80,10 @@ class PreProcessor(object):
         self.state = next_state
 
     def add_exp(self, action, reward, next_state, done):
-        # Buffer currently set to hold only last 4 experiences
-        # Amount needed for Atari games preprocessing
+        '''
+        Buffer currently set to hold only last 4 experiences
+        Amount needed for Atari games preprocessing
+        '''
         self.exp_queue.append([self.state, action, reward, next_state, done])
         # TODO parametrize max length to top
         if (self.exp_queue_size() > self.MAX_QUEUE_SIZE):
@@ -105,7 +109,7 @@ class NoPreProcessor(PreProcessor):
         return self.state
 
     def preprocess_memory(self, action, reward, next_state, done):
-        # No state processing
+        '''No state processing'''
         self.add_exp(action, reward, next_state, done)
         (state, action, reward, next_state, done) = self.exp_queue[-1]
         # TODO this is a bit odd, since now we have add_exp_processed and
@@ -130,7 +134,7 @@ class StackStates(PreProcessor):
         return np.concatenate([self.previous_state, self.state])
 
     def preprocess_memory(self, action, reward, next_state, done):
-        # Concatenates previous + current states
+        '''Concatenate: previous + current states'''
         self.add_exp(action, reward, next_state, done)
         if (self.exp_queue_size() < 1):  # insufficient queue
             return
@@ -162,7 +166,7 @@ class DiffStates(PreProcessor):
         return self.state - self.previous_state
 
     def preprocess_memory(self, action, reward, next_state, done):
-        # Change in state params, curr_state - last_state
+        '''Change in state, curr_state - last_state'''
         self.add_exp(action, reward, next_state, done)
         if (self.exp_queue_size() < 1):  # insufficient queue
             return

--- a/rl/preprocessor.py
+++ b/rl/preprocessor.py
@@ -131,7 +131,8 @@ class StackStates(PreProcessor):
         log_self(self)
 
     def preprocess_state(self):
-        return np.concatenate([self.previous_state, self.state])
+        processed_state = np.concatenate([self.previous_state, self.state])
+        return processed_state
 
     def preprocess_memory(self, action, reward, next_state, done):
         '''Concatenate: previous + current states'''
@@ -139,7 +140,7 @@ class StackStates(PreProcessor):
         if (self.exp_queue_size() < 2):  # insufficient queue
             return
         (state, action, reward, next_state, done) = self.exp_queue[-1]
-        processed_state = np.concatenate([self.exp_queue[-2][0], state])
+        processed_state = self.preprocess_state()
         processed_next_state = np.concatenate([state, next_state])
         if (self.exp_queue_size() == 1):
             logger.debug("State shape: {}".format(processed_state.shape))
@@ -148,6 +149,8 @@ class StackStates(PreProcessor):
         self.agent.memory.add_exp_processed(
             processed_state, action, reward,
             # TODO ensure we want to add processed_next_state as state
+            # TODO given that processed_next_state, processed_next_state
+            # the external passing then setting from agent is justified
             processed_next_state, processed_next_state, done)
 
 
@@ -163,7 +166,8 @@ class DiffStates(PreProcessor):
         log_self(self)
 
     def preprocess_state(self):
-        return self.state - self.previous_state
+        processed_state = self.state - self.previous_state
+        return processed_state
 
     def preprocess_memory(self, action, reward, next_state, done):
         '''Change in state, curr_state - last_state'''
@@ -171,7 +175,7 @@ class DiffStates(PreProcessor):
         if (self.exp_queue_size() < 2):  # insufficient queue
             return
         (state, action, reward, next_state, done) = self.exp_queue[-1]
-        processed_state = state - self.exp_queue[-2][0]
+        processed_state = self.preprocess_state()
         processed_next_state = next_state - state
         if (self.exp_queue_size() == 1):
             logger.debug("State shape: {}".format(processed_state.shape))

--- a/rl/preprocessor.py
+++ b/rl/preprocessor.py
@@ -136,7 +136,7 @@ class StackStates(PreProcessor):
     def preprocess_memory(self, action, reward, next_state, done):
         '''Concatenate: previous + current states'''
         self.add_exp(action, reward, next_state, done)
-        if (self.exp_queue_size() < 1):  # insufficient queue
+        if (self.exp_queue_size() < 2):  # insufficient queue
             return
         (state, action, reward, next_state, done) = self.exp_queue[-1]
         processed_state = np.concatenate([self.exp_queue[-2][0], state])
@@ -168,7 +168,7 @@ class DiffStates(PreProcessor):
     def preprocess_memory(self, action, reward, next_state, done):
         '''Change in state, curr_state - last_state'''
         self.add_exp(action, reward, next_state, done)
-        if (self.exp_queue_size() < 1):  # insufficient queue
+        if (self.exp_queue_size() < 2):  # insufficient queue
             return
         (state, action, reward, next_state, done) = self.exp_queue[-1]
         processed_state = state - self.exp_queue[-2][0]
@@ -207,7 +207,7 @@ class Atari(PreProcessor):
 
     def preprocess_memory(self, action, reward, next_state, done):
         self.add_exp(action, reward, next_state, done)
-        if (self.exp_queue_size() < 3):  # insufficient queue
+        if (self.exp_queue_size() < 4):  # insufficient queue
             return
         (state, action, reward, next_state, done) = self.exp_queue[-1]
         processed_next_state_queue = (

--- a/rl/util.py
+++ b/rl/util.py
@@ -51,7 +51,7 @@ def wrap_text(text):
 def print_line(line='-'):
     if environ.get('CI'):
         return
-    rows, columns = os.popen('stty size', 'r').read().split()
+    _rows, columns = os.popen('stty size', 'r').read().split()
     line_str = line*int(columns)
     print(line_str)
 

--- a/rl/util.py
+++ b/rl/util.py
@@ -84,7 +84,7 @@ def timestamp_elapse_to_seconds(s1):
 
 def basic_stats(array):
     '''generate the basic stats for a numerical array'''
-    if not array:
+    if not len(array):
         return None
     return {
         'min': np.min(array).astype(float),
@@ -220,23 +220,26 @@ def mp_run_helper(experiment):
     return experiment.run()
 
 
+def prefix_id_from_experiment_id(experiment_id):
+    str_arr = experiment_id.split('_')
+    if str_arr[-1].startswith('e'):
+        str_arr.pop()
+    return '_'.join(str_arr)
+
+
 def load_data_from_experiment_id(experiment_id):
     experiment_id = experiment_id.split(
         '/').pop().split('.').pop(0)
-    data_filename = './data/{}.json'.format(experiment_id)
+    prefix_id = prefix_id_from_experiment_id(experiment_id)
+    data_filename = './data/{}/{}.json'.format(prefix_id, experiment_id)
     data = json.loads(open(data_filename).read())
     return data
 
 
-def prefix_id_from_experiment_id(experiment_id):
-    str_arr = experiment_id.split('_')
-    str_arr.pop()
-    return '_'.join(str_arr)
-
-
 def load_data_array_from_prefix_id(prefix_id):
     # to load all ./data files for a series of experiments
-    data_path = './data'
+    prefix_id = prefix_id_from_experiment_id(prefix_id)
+    data_path = './data/{}'.format(prefix_id)
     experiment_id_array = [
         f for f in os.listdir(data_path)
         if (os.path.isfile(os.path.join(data_path, f)) and

--- a/rl/util.py
+++ b/rl/util.py
@@ -6,6 +6,7 @@ import json
 import logging
 import numpy as np
 import os
+import sys
 from datetime import datetime, timedelta
 from os import path, environ
 from textwrap import wrap
@@ -29,7 +30,7 @@ args = parser.parse_args([]) if environ.get('CI') else parser.parse_args()
 
 # Goddam python logger
 logger = logging.getLogger(__name__)
-handler = logging.StreamHandler()
+handler = logging.StreamHandler(sys.stdout)
 handler.setFormatter(
     logging.Formatter('[%(asctime)s] %(levelname)s: %(message)s'))
 logger.setLevel(args.loglevel)

--- a/rl/util.py
+++ b/rl/util.py
@@ -242,7 +242,7 @@ def load_data_array_from_prefix_id(prefix_id):
     data_path = './data/{}'.format(prefix_id)
     experiment_id_array = [
         f for f in os.listdir(data_path)
-        if (os.path.isfile(os.path.join(data_path, f)) and
+        if (path.isfile(path.join(data_path, f)) and
             f.startswith(prefix_id) and
             f.endswith('.json'))
     ]

--- a/test/test_rl.py
+++ b/test/test_rl.py
@@ -1,5 +1,5 @@
 import unittest
-import pytest
+import pandas as pd
 from os import environ
 environ['CI'] = environ.get('CI') or 'true'
 from rl.experiment import run
@@ -9,18 +9,23 @@ class DQNTest(unittest.TestCase):
 
     def test_run_gym_tour(self):
         metrics_df = run('dummy')
+        assert isinstance(metrics_df, pd.DataFrame)
 
     def test_run_q_table(self):
         metrics_df = run('q_table')
+        assert isinstance(metrics_df, pd.DataFrame)
 
     def test_run_dqn(self):
         metrics_df = run('dqn')
+        assert isinstance(metrics_df, pd.DataFrame)
 
     def test_run_double_dqn(self):
         metrics_df = run('double_dqn')
+        assert isinstance(metrics_df, pd.DataFrame)
 
     def test_run_mountain_double_dqn(self):
         metrics_df = run('mountain_double_dqn')
+        assert isinstance(metrics_df, pd.DataFrame)
 
     # def test_run_all(self):
     #     for x in game_specs.keys():


### PR DESCRIPTION
Main bulk of preprocessing refactor to clean up code and simplify logic.

- [x] absorb all preprocessing logic into PreProcess classes, to reduce the top level complexity
- [x] try running lunar_dqn with preprocessor, broken, but fixed due to below;
- [x] use better preprocessing logic and reasoning: all env variables will go though a preprocessor, and agent can only receive variables through preprocessor at all times, and can never access env directly. This makes for clear assignment of variables, and agent cannot accidentally acquire wrong experience from env (which caused the breakage above)
- [x] make preprocessor preprocess the entire `env` at init
- [x] this change allows removal of `add_exp_processed`, which is now redundant as `add_exp` always add from preprocessed info
- [x] refactor `PreProcess` methods - made more concise and verbose.
- [x] serialize experiment data by folders now
- [x] add new metric `mean_rewards_per_epi`
- [x] fix ssh: use `npm run remote`
- [x] fix breakout. now runnable
- [x] refactor `recompile_model` into `update` and remove time cond into `to_train` from main loop
- [x] use early termination: stop experiment if its solved ratio is not 1 (i.e. has a failure). This is greedy but fast
- [x] Q value numpy exception still exists; add catcher to stop experiment elegantly when exceptions are thrown