### PR TITLE
remove maxnorm to fix failed dqn runs

### DIFF
--- a/rl/agent/atari_conv_dqn.py
+++ b/rl/agent/atari_conv_dqn.py
@@ -2,7 +2,6 @@ from rl.agent.dqn import DQN
 from keras.layers.core import Dense, Flatten
 from keras.layers.convolutional import Convolution2D
 from keras.optimizers import RMSprop
-from keras.constraints import maxnorm
 from keras import backend as K
 K.set_image_dim_ordering('tf')
 
@@ -24,8 +23,7 @@ class ConvDQN(DQN):
                 subsample=self.hidden_layers[0][3],
                 input_shape=(self.env_spec['state_dim']),
                 activation=self.hidden_layers_activation,
-                init='lecun_uniform',
-                W_constraint=maxnorm(3)))
+                init='lecun_uniform'))
 
         if (len(self.hidden_layers) > 1):
             for i in range(1, len(self.hidden_layers)):
@@ -36,14 +34,12 @@ class ConvDQN(DQN):
                         self.hidden_layers[i][2],
                         subsample=self.hidden_layers[i][3],
                         activation=self.hidden_layers_activation,
-                        init='lecun_uniform',
-                        W_constraint=maxnorm(3)))
+                        init='lecun_uniform'))
 
         model.add(Flatten())
         model.add(Dense(256,
                         init='lecun_uniform',
-                        activation=self.hidden_layers_activation,
-                        W_constraint=maxnorm(3)))
+                        activation=self.hidden_layers_activation))
 
         return model
 

--- a/rl/agent/double_dqn.py
+++ b/rl/agent/double_dqn.py
@@ -24,17 +24,20 @@ class DoubleDQN(DQN):
         return self.model, self.model2
 
     def compute_Q_states(self, minibatch):
-        Q_states = self.model.predict(minibatch['states'])
+        clip_val = 10000
+        Q_states = np.clip(
+            self.model.predict(minibatch['states']), -clip_val, clip_val)
         # Different from (single) dqn: Select max using model 2
-        Q_next_states_select = self.model2.predict(
-            minibatch['next_states'])
+        Q_next_states_select = np.clip(
+            self.model2.predict(minibatch['next_states']), -clip_val, clip_val)
         Q_next_states_max_ind = np.argmax(Q_next_states_select, axis=1)
         # if more than one max, pick 1st
         if (Q_next_states_max_ind.shape[0] > 1):
             Q_next_states_max_ind = Q_next_states_max_ind[0]
 
         # same as dqn again, but use Q_next_states_max_ind above
-        Q_next_states = self.model.predict(minibatch['next_states'])
+        Q_next_states = np.clip(
+            self.model.predict(minibatch['next_states']), -clip_val, clip_val)
         Q_next_states_max = Q_next_states[:, Q_next_states_max_ind]
         return (Q_states, Q_next_states_max)
 

--- a/rl/agent/dqn.py
+++ b/rl/agent/dqn.py
@@ -4,7 +4,6 @@ from rl.util import logger, log_self
 from keras.models import Sequential
 from keras.layers.core import Dense
 from keras.optimizers import SGD
-from keras.constraints import maxnorm
 
 
 class DQN(Agent):
@@ -47,16 +46,14 @@ class DQN(Agent):
         model.add(Dense(self.hidden_layers[0],
                         input_shape=(self.env_spec['state_dim'],),
                         activation=self.hidden_layers_activation,
-                        init='lecun_uniform',
-                        W_constraint=maxnorm(3)))
+                        init='lecun_uniform'))
 
         # inner hidden layer: no specification of input shape
         if (len(self.hidden_layers) > 1):
             for i in range(1, len(self.hidden_layers)):
                 model.add(Dense(self.hidden_layers[i],
                                 init='lecun_uniform',
-                                activation=self.hidden_layers_activation,
-                                W_constraint=maxnorm(3)))
+                                activation=self.hidden_layers_activation))
 
         return model
 
@@ -68,8 +65,7 @@ class DQN(Agent):
         self.build_hidden_layers(model)
         model.add(Dense(self.env_spec['action_dim'],
                         init='lecun_uniform',
-                        activation=self.output_layer_activation,
-                        W_constraint=maxnorm(3)))
+                        activation=self.output_layer_activation))
         logger.info("Model summary")
         model.summary()
         self.model = model

--- a/rl/agent/dqn.py
+++ b/rl/agent/dqn.py
@@ -133,8 +133,10 @@ class DQN(Agent):
     def compute_Q_states(self, minibatch):
         # note the computed values below are batched in array
         clip_val = 10000
-        Q_states = np.clip(self.model.predict(minibatch['states']),  -clip_val, clip_val)
-        Q_next_states = np.clip(self.model.predict(minibatch['next_states']), -clip_val, clip_val)
+        Q_states = np.clip(
+            self.model.predict(minibatch['states']), -clip_val, clip_val)
+        Q_next_states = np.clip(
+            self.model.predict(minibatch['next_states']), -clip_val, clip_val)
         Q_next_states_max = np.amax(Q_next_states, axis=1)
         return (Q_states, Q_next_states_max)
 

--- a/rl/asset/problems.json
+++ b/rl/asset/problems.json
@@ -3,7 +3,7 @@
     "RENDER": true,
     "GYM_ENV_NAME": "CartPole-v0",
     "SOLVED_MEAN_REWARD": 195.0,
-    "MAX_EPISODES": 10,
+    "MAX_EPISODES": 30,
     "REWARD_MEAN_LEN": 100
   },
   "CartPole-v0": {

--- a/rl/asset/sess_specs.json
+++ b/rl/asset/sess_specs.json
@@ -22,7 +22,7 @@
     "dev_dqn": {
         "problem": "DevCartPole-v0",
         "Agent": "dqn.DQN",
-        "Memory": "HighLowMemoryWithForgetting",
+        "Memory": "LinearMemoryWithForgetting",
         "Policy": "BoltzmannPolicy",
         "PreProcessor": "NoPreProcessor",
         "param": {
@@ -31,11 +31,12 @@
             "gamma": 0.99,
             "hidden_layers_shape": [4],
             "hidden_layers_activation": "sigmoid",
-            "exploration_anneal_episodes": 10,
-            "epi_change_learning_rate": 5
+            "exploration_anneal_episodes": 10
         },
         "param_range": {
-            "learning_rate": [0.01, 0.1]
+            "learning_rate": [0.01, 0.1],
+            "gamma": [0.95, 0.99],
+            "exploration_anneal_episodes": [10, 20]
         }
     },
     "dqn": {

--- a/rl/experiment.py
+++ b/rl/experiment.py
@@ -214,7 +214,8 @@ class Session(object):
             sys_vars['RENDER'] = False
         if environ.get('CI'):
             sys_vars['RENDER'] = False
-            sys_vars['MAX_EPISODES'] = 4
+            if self.problem != 'DevCartPole-v0':
+                sys_vars['MAX_EPISODES'] = 4
         self.sys_vars = sys_vars
         self.reset_sys_vars()
         return self.sys_vars

--- a/rl/experiment.py
+++ b/rl/experiment.py
@@ -464,7 +464,7 @@ class Experiment(object):
             'num_of_sessions': len(sys_vars_array),
             'solved_num_of_sessions': len(solved_sys_vars_array),
             'solved_ratio_of_sessions': float(len(
-                solved_sys_vars_array)) / len(sys_vars_array),
+                solved_sys_vars_array)) / self.times,
             'mean_rewards_stats': basic_stats(mean_rewards_array),
             'mean_rewards_per_epi_stats': basic_stats(
                 mean_rewards_per_epi_array),

--- a/test/test_rl.py
+++ b/test/test_rl.py
@@ -7,26 +7,24 @@ from rl.experiment import run
 
 class DQNTest(unittest.TestCase):
 
-    def test_run_gym_tour(self):
+    def test_gym_tour(self):
         metrics_df = run('dummy')
         assert isinstance(metrics_df, pd.DataFrame)
 
-    def test_run_q_table(self):
+    def test_q_table(self):
         metrics_df = run('q_table')
         assert isinstance(metrics_df, pd.DataFrame)
 
-    def test_run_dqn(self):
+    def test_dqn(self):
         metrics_df = run('dqn')
         assert isinstance(metrics_df, pd.DataFrame)
 
-    def test_run_double_dqn(self):
+    def test_double_dqn(self):
         metrics_df = run('double_dqn')
         assert isinstance(metrics_df, pd.DataFrame)
 
-    def test_run_mountain_double_dqn(self):
-        metrics_df = run('mountain_double_dqn')
-        assert isinstance(metrics_df, pd.DataFrame)
-
-    # def test_run_all(self):
-    #     for x in game_specs.keys():
-    #         metrics_df = run(x)
+    def test_dev_dqn_pass(self):
+        metrics_df = run('dev_dqn')
+        max_total_rewards = metrics_df['max_total_rewards_stats_max'][0]
+        print(max_total_rewards)
+        assert max_total_rewards > 100


### PR DESCRIPTION
simple dqn cartpole fails to run at some commits ago. Identify the breaking commit at:
2e1a18e8e7ac233b179d3b68f448dbd0ca140995 fix Q states bug with max norm addition,
whereas its previous still runs at 98d32afd8ffea3d7c69043c806272b20b5e76266 for fix matplotlib for CI

Also, setting `W_constraint=None` is not sufficient to fix it. The key has to be removed entirely in the Keras layer construction

- [x] remove `maxnorm` and also `W_constraint` key entire from all Keras layers
- [x] fix the Q_states overflow error from `model.predict` by clipping values
- [x] add CI check with requirement that simple dqn cartpole passes
- [x] use `experiment.times` to accurately calculate solved ratios