### PR TITLE
GPU and Theano

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,19 +14,21 @@ This was started from the Eligible Reinforcement Learning event, and we just kep
 ```shell
 git clone https://github.com/kengz/openai_gym.git
 cd openai_gym
-python setup.py install
+bin/setup
 ```
 
-*Note that by default it installs Tensorflow for Python3 on MacOS. [If you're on a different platform, choose the correct binary to install from TF.](https://www.tensorflow.org/get_started/os_setup#pip_installation)*
+The binary at `bin/setup` installs all the needed dependencies, which includes the basic OpenAI gym, Tensorflow (for dev), Theano(for faster production), Keras.
+
+*Note the Tensorflow is defaulted to CPU Mac or GPU Linux. [If you're on a different platform, choose the correct binary to install from TF.](https://www.tensorflow.org/get_started/os_setup#pip_installation)*
 
 ```shell
 # default option
 TF_BINARY_URL=https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-0.12.1-py3-none-any.whl
 # install from the TF_BINARY_URL
-sudo pip install --upgrade $TF_BINARY_URL
+sudo pip3 install -U $TF_BINARY_URL
 ```
 
-### Complete
+### Full OpenAI Gym Environments
 
 To run more than just the classic control gym env, we need to install the OpenAI gym fully. We refer to the [Install Everything](https://github.com/openai/gym#installing-everything) of the repo (which is still broken at the time of writing).
 
@@ -34,7 +36,7 @@ To run more than just the classic control gym env, we need to install the OpenAI
 brew install cmake boost boost-python sdl2 swig wget
 git clone https://github.com/openai/gym.git
 cd gym
-pip install -e '.[all]'
+pip3 install -e '.[all]'
 ```
 
 Try to run a Lunar Lander env, it will break (unless they fix it):
@@ -51,17 +53,17 @@ If it fails, debug as follow (and repeat once more if it fails again, glorious p
 pip3 uninstall Box2D box2d-py
 git clone https://github.com/pybox2d/pybox2d
 cd pybox2d/
-python setup.py clean
-python setup.py build
-python setup.py install
+python3 setup.py clean
+python3 setup.py build
+python3 setup.py install
 ```
 
 To run Atari envs three additional dependencies are required
 
 ```shell
-pip install atari_py
-pip install Pillow
-pip install PyOpenGL
+pip3 install atari_py
+pip3 install Pillow
+pip3 install PyOpenGL
 ```
 
 Then check that it works with
@@ -81,7 +83,7 @@ For auto-syncing `data/` files, we use Gulp. This sets up a watcher for automati
 ```shell
 npm install --global gulp-cli
 npm install --save-dev gulp gulp-watch gulp-changed
-run the
+# run the file watcher
 gulp
 ```
 
@@ -99,7 +101,7 @@ npm run clear
 To customize your run commands, use plain python:
 
 ```shell
-python3 main.py -s lunar_dqn -b -g | tee -a ./data/terminal.log
+python3 main.py -bgp -s lunar_dqn -t 5 | tee -a ./data/terminal.log
 ```
 
 The extra flags are:
@@ -123,7 +125,7 @@ screen
 # enter the screen
 npm run remote
 # or full python command goes like
-xvfb-run -a -s "-screen 0 1400x900x24" -- python3 main.py -b | tee -a ./data/terminal.log
+xvfb-run -a -s "-screen 0 1400x900x24" -- python3 main.py -bgp -s lunar_dqn -t 5 | tee -a ./data/terminal.log
 # use Cmd+A+D to detach from screen, then Cmd+D to disconnect ssh
 # use screen -r to resume screen next time
 ```

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ cd openai_gym
 bin/setup
 ```
 
+Then, setup your `~/.keras/keras.json`. See example files in `rl/asset/keras.json`. We recommend Tensorflow for experimentation and multi-GPU, since it's much nicer to work with. Use Theano when you're training a single finalized model since it's faster.
+
 The binary at `bin/setup` installs all the needed dependencies, which includes the basic OpenAI gym, Tensorflow (for dev), Theano(for faster production), Keras.
 
 *Note the Tensorflow is defaulted to CPU Mac or GPU Linux. [If you're on a different platform, choose the correct binary to install from TF.](https://www.tensorflow.org/get_started/os_setup#pip_installation)*

--- a/bin/setup
+++ b/bin/setup
@@ -70,6 +70,7 @@ else
   TF_BINARY_URL=https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-0.12.1-cp35-cp35m-linux_x86_64.whl
 fi
 sudo python3 -m pip install $TF_BINARY_URL
+python3 -c "import tensorflow; print('tensorflow version:'); print(tensorflow.__version__)"
 
 # install theano
 if which clang >/dev/null; then
@@ -79,7 +80,10 @@ else
     brew install --with-clang llvm
   fi
 fi
-sudo python3 -m pip install git+https://github.com/Theano/Theano.git
+# sudo pip3 install --upgrade --no-deps git+git://github.com/Theano/Theano.git
+sudo python3 -m pip install theano==0.8.2
+python3 -c "import theano; print('theano version:'); print(theano.__version__)"
+
 
 # install keras
 sudo python3 -m pip install keras

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,85 @@
+#!/bin/bash
+# This script runs the same sequence as the CircleCI build
+
+# Fail on the first error; killable by SIGINT
+set -e
+trap "exit" INT
+
+# install system dependencies
+if [ $(uname) == "Darwin" ]; then
+  if which brew >/dev/null; then
+    echo "Brew is already installed"
+  else
+    ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+  fi
+else
+  sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test && sudo apt-get update
+  sudo apt-get install -y gcc-4.9 g++-4.9 libhdf5-dev libopenblas-dev git
+fi
+
+# install python
+if which python3 >/dev/null; then
+  echo "Python3 is already installed"
+else
+  if [ $(uname) == "Darwin" ]; then
+    brew install python3
+  else
+    sudo apt-get -y install python3-dev python3-pip python3-setuptools
+  fi
+fi
+
+# install nodejs (for npm and file watcher)
+if which node >/dev/null; then
+  echo "Nodejs is already installed"
+else
+  if [ $(uname) == "Darwin" ]; then
+    brew install node
+  else
+    curl -sL https://deb.nodesource.com/setup_7.x | sudo -E bash -
+    sudo apt-get install -y nodejs
+  fi
+fi
+
+# install npm modules
+if [ -d ./node_modules ]; then
+  echo "Npm modules already installed"
+else
+  npm install
+fi
+
+# install common dependencies from from
+if python3 -m pip show six h5py numpy scipy matplotlib pandas gym >/dev/null; then
+  echo "Pip modules already installed"
+else
+  sudo python3 -m pip install -U pip
+  sudo python3 -m pip install six
+  sudo python3 -m pip install h5py
+  sudo python3 -m pip install numpy
+  sudo python3 -m pip install scipy
+  sudo python3 -m pip install matplotlib
+  sudo python3 -m pip install pandas
+  sudo python3 -m pip install pytest-cov
+  sudo python3 -m pip install git+https://github.com/openai/gym.git
+  git clone https://github.com/pybox2d/pybox2d && cd pybox2d/ && python3 setup.py clean && python3 setup.py build && python3 setup.py install
+fi
+
+# install tensorflow
+if [ $(uname) == "Darwin" ]; then
+  TF_BINARY_URL=https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-0.12.1-py3-none-any.whl
+else
+  TF_BINARY_URL=https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-0.12.1-cp35-cp35m-linux_x86_64.whl
+fi
+sudo python3 -m pip install $TF_BINARY_URL
+
+# install theano
+if which clang >/dev/null; then
+  echo "Python3 is already installed"
+else
+  if [ $(uname) == "Darwin" ]; then
+    brew install --with-clang llvm
+  fi
+fi
+sudo python3 -m pip install git+https://github.com/Theano/Theano.git
+
+# install keras
+sudo python3 -m pip install keras

--- a/circle.yml
+++ b/circle.yml
@@ -3,29 +3,26 @@ machine:
     version: 3.5.2
   environment:
     CODECLIMATE_REPO_TOKEN: 082d5472ff9fad9fcd560b16b714a312093ce064107094d07f23975601f050ab
-    TF_BINARY_URL: https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.11.0rc1-cp35-cp35m-linux_x86_64.whl
+    TF_BINARY_URL: https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.12.1-cp35-cp35m-linux_x86_64.whl
 
 dependencies:
   pre:
     - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test && sudo apt-get update
-    - sudo apt-get install -y gcc-4.9 g++-4.9 libhdf5-dev
+    - sudo apt-get install -y gcc-4.9 g++-4.9 libhdf5-dev libopenblas-dev git python3-dev
     - pip install -U pip
+    - pip install six
     - pip install h5py
     - pip install numpy
     - pip install scipy
     - pip install matplotlib
     - pip install pandas
-    - pip install hyperopt
+    - pip install pytest-cov
   override:
-    - pip install $TF_BINARY_URL
-    - pip install git+https://github.com/tflearn/tflearn.git
-    - pip install keras
     - pip install git+https://github.com/openai/gym.git
     - git clone https://github.com/pybox2d/pybox2d && cd pybox2d/ && python setup.py clean && python setup.py build && python setup.py install
-    - pip install codeclimate-test-reporter
-    - pip install pytest-cov
-
+    - pip install $TF_BINARY_URL
+    - pip install git+https://github.com/Theano/Theano.git
+    - pip install keras
 test:
   override:
     - xvfb-run -a -s "-screen 0 1400x900x24" -- python setup.py test
-    - codeclimate-test-reporter

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,11 @@
+six==1.10.0
 h5py==2.6.0
 numpy==1.11.1
 scipy==0.18.0
 matplotlib==1.4.3
 pandas==0.18.1
-hyperopt==0.1
-https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-0.11.0rc1-py3-none-any.whl
-git+https://github.com/tflearn/tflearn.git
-Keras==1.1.0
-git+https://github.com/openai/gym.git
-codeclimate-test-reporter==0.1.2
 pytest-cov==2.4.0
+git+https://github.com/openai/gym.git
+https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-0.12.1-py3-none-any.whl
+git+https://github.com/Theano/Theano.git
+Keras==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ pandas==0.18.1
 pytest-cov==2.4.0
 git+https://github.com/openai/gym.git
 https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-0.12.1-py3-none-any.whl
-git+https://github.com/Theano/Theano.git
+Theano==0.8.2
 Keras==1.1.0

--- a/rl/__init__.py
+++ b/rl/__init__.py
@@ -1,12 +1,12 @@
 # curse of python pathing, hack to solve rel import
+import glob
 import sys
 from os import path
+from os.path import dirname, basename, isfile
 file_path = path.normpath(path.join(path.dirname(__file__)))
 sys.path.insert(0, file_path)
 
 # another py curse, expose to prevent 'agent.<agent>' call
-from os.path import dirname, basename, isfile
-import glob
 pattern = "/*.py"
-modules = glob.glob(dirname(__file__)+pattern)
+modules = glob.glob(dirname(__file__) + pattern)
 __all__ = [basename(f)[:-3] for f in modules if isfile(f)]

--- a/rl/agent/atari_conv_dqn.py
+++ b/rl/agent/atari_conv_dqn.py
@@ -3,7 +3,6 @@ from keras.layers.core import Dense, Flatten
 from keras.layers.convolutional import Convolution2D
 from keras.optimizers import RMSprop
 from keras import backend as K
-K.set_image_dim_ordering('tf')
 
 
 class ConvDQN(DQN):

--- a/rl/asset/.theanorc
+++ b/rl/asset/.theanorc
@@ -1,0 +1,6 @@
+[global]
+floatX = float32
+device = gpu0
+
+[lib]
+cnmem = 0.2

--- a/rl/asset/keras.json
+++ b/rl/asset/keras.json
@@ -1,0 +1,6 @@
+{
+    "epsilon": 1e-07,
+    "image_dim_ordering": "tf",
+    "floatx": "float32",
+    "backend": "tensorflow"
+}

--- a/rl/util.py
+++ b/rl/util.py
@@ -122,18 +122,6 @@ def timestamp_elapse_to_seconds(s1):
     return secs
 
 
-def basic_stats(array):
-    '''generate the basic stats for a numerical array'''
-    if not len(array):
-        return None
-    return {
-        'min': np.min(array).astype(float),
-        'max': np.max(array).astype(float),
-        'mean': np.mean(array).astype(float),
-        'std': np.std(array).astype(float),
-    }
-
-
 # own custom sorted json serializer, cuz python
 def to_json(o, level=0):
     INDENT = 2
@@ -285,7 +273,18 @@ def load_data_array_from_prefix_id(prefix_id):
             for experiment_id in experiment_id_array]
 
 
-# TODO move to util
+def basic_stats(array):
+    '''generate the basic stats for a numerical array'''
+    if not len(array):
+        return None
+    return {
+        'min': np.min(array).astype(float),
+        'max': np.max(array).astype(float),
+        'mean': np.mean(array).astype(float),
+        'std': np.std(array).astype(float),
+    }
+
+
 def configure_gpu():
     '''detect GPU options and configure'''
     if K.backend() != 'tensorflow':


### PR DESCRIPTION
- [x] add Theano. For now use only when doing single-process training for production. For development with multi-GPU stick to Tensorflow for now. Find the [speed benchmark here](http://www.ccri.com/2016/12/09/torch-vs-tensorflow-vs-theano/). Theano can be x4 faster in some cases, but not always. Use TF to save the previous human dev time instead.
- [x] add `bin/setup` binary for dependency installation
- [x] update README
- [x] add example config files in `rl/asset` for `.theanorc`, `keras.json`